### PR TITLE
 Add run configuration to run the extension without other extensions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,13 +9,28 @@
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
+			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "npm: watch"
+		},
+		{
+			"name": "Run Only This Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--disable-extensions"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "npm: watch"
 		}
 	]
 }


### PR DESCRIPTION
This also makes a small change to turn the pre-launch task into `npm: watch`, which seems to be how the [actual sample](https://github.com/microsoft/vscode-extension-samples/tree/main) does it, but not how the yeoman setup did it for me.